### PR TITLE
Link catkin dependencies correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 
 project(ati_ft_sensor)
 
-find_package(catkin REQUIRED COMPONENTS mpi_cmake_modules real_time_tools)
+find_package(catkin REQUIRED COMPONENTS
+    mpi_cmake_modules
+    real_time_tools)
 
 # This macro sets the C++ preprocessor flags "XENOMAI", "RT_PREEMPT", or
 # "UBUNTU" according to the current operating system.
@@ -69,7 +71,7 @@ endif()
 
 ADD_LIBRARY(${PROJECT_NAME} src/AtiFTSensor.cpp)
 target_link_libraries(${PROJECT_NAME}
-  real_time_tools)
+    ${catkin_LIBRARIES})
 
 if(Xenomai_FOUND)
   target_link_libraries(${PROJECT_NAME}

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>ati_ft_sensor</name>
   <version>1.0.0</version>
   <description>sl</description>
@@ -9,8 +9,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend> real_time_tools </build_depend>
-  <run_depend>   real_time_tools </run_depend>
+  <build_depend>mpi_cmake_modules</build_depend>
+  <depend>real_time_tools</depend>
 
   <export>
   </export>


### PR DESCRIPTION
- Do not specify "real_time_tools" explicitly in `target_link_libraries` but use the `${catkin_LIBRARIES}` variable.
- Add build dependency on mpi_cmake_modules