### PR TITLE
Remove unused arguments of main function

### DIFF
--- a/tests/test_sensor.cpp
+++ b/tests/test_sensor.cpp
@@ -68,7 +68,7 @@ THREAD_FUNCTION_RETURN_TYPE logTask(void*)
 
 
 
-int main(int, char*)
+int main()
 {
   real_time_tools::RealTimeThread thread_;
   thread_.create_realtime_thread(&logTask, nullptr);


### PR DESCRIPTION
## Description

clang was complaining that second argument should be of type `char**`.
Since they are anyway not used, remove them completely.


## How I Tested

Just compiled.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
