### PR TITLE
fix typo in ros2 demo command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ You can run it via
   ```
 or (with ROS2)
   ```
-  ros2 run ati_ft_sensor ait_ft_sensor_test_sensor
+  ros2 run ati_ft_sensor ati_ft_sensor_test_sensor
   ```
 You also can run it with Xenomai by adding `_stream` to the previous commands.
 


### PR DESCRIPTION
## Description

Changed part of the command from "ait" to "ati."

Wasn't able to get line 70 to work, so I'm not sure if that's a typo as well.

## How I Tested

"ait" does not run, "ati" does run. Tab autocompletion also suggests "ati."

## I fulfilled the following requirements

Just fixing a typo in a sample code snippet, so formatting and style requirements do not apply.